### PR TITLE
Run tests on every push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: GH Actions - Release
 on:
   workflow_run:
     workflows: ["Test"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Test
-on: [pull_request]
+on: [push]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: GH Actions - Test
 on: [push]
 
 jobs:


### PR DESCRIPTION
Currently tests only run on pull requests. This should cause them to run on every push, which should also fix the issue where releases aren't being run when a PR is merged to `main`.